### PR TITLE
fix: remove npm plugin from semantic-release configuration

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,6 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    "@semantic-release/npm",
     "@semantic-release/git",
     "@semantic-release/github"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^11.0.4",
-        "@semantic-release/npm": "^12.0.2",
         "@semantic-release/release-notes-generator": "^14.0.3",
         "@size-limit/preset-big-lib": "^11.2.0",
         "@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.4",
-    "@semantic-release/npm": "^12.0.2",
     "@semantic-release/release-notes-generator": "^14.0.3",
     "@size-limit/preset-big-lib": "^11.2.0",
     "@types/js-cookie": "^3.0.6",


### PR DESCRIPTION
- Remove @semantic-release/npm plugin since we don't publish to npm
- Keep only GitHub releases and Git tags for versioning
- Fix configuration mismatch that was causing errors
- Clean up unused npm dependencies